### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy_pypi.yaml
+++ b/.github/workflows/deploy_pypi.yaml
@@ -1,4 +1,6 @@
 name: Deploy to PyPI and GitHub Releases
+permissions:
+  contents: write
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/ONSdigital/ons_mkdocs_theme/security/code-scanning/6](https://github.com/ONSdigital/ons_mkdocs_theme/security/code-scanning/6)

In general, the fix is to add an explicit `permissions` block to the workflow (either at the top level or within the `deploy` job) so that `GITHUB_TOKEN` has only the minimal rights needed. This avoids relying on potentially broad repository defaults and adheres to least privilege.

For this specific workflow, we must allow writing tags and releases but do not need broad write access to all scopes. The `mathieudutour/github-tag-action` and `ncipollo/release-action` both operate on repository contents/releases using `GITHUB_TOKEN`, so we need `contents: write` at minimum. The other steps (checkout, Python setup, building, and publishing to PyPI) either use secrets (`PYPI_API_TOKEN`) or do not use `GITHUB_TOKEN` at all. Therefore, the best minimal and functional configuration is to define `permissions` at the workflow root with `contents: write`. This will apply to the `deploy` job and is sufficient to push tags and create releases.

Concretely, in `.github/workflows/deploy_pypi.yaml`, insert a `permissions:` block after the `name:` and before the `on:` block:

```yaml
name: Deploy to PyPI and GitHub Releases
permissions:
  contents: write

on:
  workflow_dispatch:
```

No additional imports or methods are required; this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
